### PR TITLE
Fix with Kotlin 1.9.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ val testB by sourceSets.creating
 
 kotlinVersion("1.5.21", isPrimaryVersion = true)
 kotlinVersion("1.6.20")
+kotlinVersion("1.9.0")
 
 dependencies {
     api("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.5.21")

--- a/src/kotlin1521/kotlin/com/replaymod/gradle/remap/kotlin1521.kt
+++ b/src/kotlin1521/kotlin/com/replaymod/gradle/remap/kotlin1521.kt
@@ -1,6 +1,7 @@
 package com.replaymod.gradle.remap
 
 import org.jetbrains.kotlin.analyzer.AnalysisResult
+import org.jetbrains.kotlin.cli.common.config.KotlinSourceRoot
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.cli.jvm.compiler.NoScopeRecordCliBindingTrace
 import org.jetbrains.kotlin.cli.jvm.compiler.TopDownAnalyzerFacadeForJVM
@@ -16,3 +17,5 @@ fun analyze1521(environment: KotlinCoreEnvironment, ktFiles: List<KtFile>): Anal
         { scope: GlobalSearchScope -> environment.createPackagePartProvider(scope) }
     )
 }
+
+fun kotlinSourceRoot1521(path: String, isCommon: Boolean) = KotlinSourceRoot(path, isCommon)

--- a/src/kotlin190/kotlin/com/replaymod/gradle/remap/kotlin190.kt
+++ b/src/kotlin190/kotlin/com/replaymod/gradle/remap/kotlin190.kt
@@ -1,0 +1,5 @@
+package com.replaymod.gradle.remap
+
+import org.jetbrains.kotlin.cli.common.config.KotlinSourceRoot
+
+fun kotlinSourceRoot190(path: String, isCommon: Boolean) = KotlinSourceRoot(path, isCommon, null)

--- a/src/main/kotlin/com/replaymod/gradle/remap/Transformer.kt
+++ b/src/main/kotlin/com/replaymod/gradle/remap/Transformer.kt
@@ -73,7 +73,12 @@ class Transformer(private val map: MappingSet) {
             config.put(CommonConfigurationKeys.MODULE_NAME, "main")
             jdkHome?.let {config.setupJdk(it) }
             config.add<ContentRoot>(CLIConfigurationKeys.CONTENT_ROOTS, JavaSourceRoot(tmpDir.toFile(), ""))
-            config.add<ContentRoot>(CLIConfigurationKeys.CONTENT_ROOTS, KotlinSourceRoot(tmpDir.toAbsolutePath().toString(), false))
+            val kotlinSourceRoot = try {
+                kotlinSourceRoot1521(tmpDir.toAbsolutePath().toString(), false)
+            } catch (e: NoSuchMethodException) {
+                kotlinSourceRoot190(tmpDir.toAbsolutePath().toString(), false)
+            }
+            config.add<ContentRoot>(CLIConfigurationKeys.CONTENT_ROOTS, kotlinSourceRoot)
             config.addAll<ContentRoot>(CLIConfigurationKeys.CONTENT_ROOTS, classpath!!.map { JvmClasspathRoot(File(it)) })
             config.put<MessageCollector>(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, PrintingMessageCollector(System.err, MessageRenderer.GRADLE_STYLE, true))
 


### PR DESCRIPTION
In 1.9, a field was added in `KotlinSourceRoot` to store information for Kotlin Multiplatform; however, since remap should only work on JVM, `null` can be passed.