### PR TITLE
Fix NEW target

### DIFF
--- a/src/main/kotlin/com/replaymod/gradle/remap/PsiMapper.kt
+++ b/src/main/kotlin/com/replaymod/gradle/remap/PsiMapper.kt
@@ -532,7 +532,7 @@ internal class PsiMapper(
 
     private fun remapMixinTarget(target: String): String {
         return when {
-            target.startsWith('(') -> return remapMethodDesc(target)
+            target.startsWith('(') -> remapMethodDesc(target)
             target.contains(':') || target.contains('(') -> remapFullyQualifiedMethodOrField(target)
             target[0] == 'L' -> remapInternalType(target)
             else -> remapInternalType("L$target;").drop(1).dropLast(1)

--- a/src/main/kotlin/com/replaymod/gradle/remap/PsiMapper.kt
+++ b/src/main/kotlin/com/replaymod/gradle/remap/PsiMapper.kt
@@ -531,14 +531,11 @@ internal class PsiMapper(
     }
 
     private fun remapMixinTarget(target: String): String {
-        return if (target.contains(':') || target.contains('(')) {
-            remapFullyQualifiedMethodOrField(target)
-        } else {
-            if (target[0] == 'L') {
-                remapInternalType(target)
-            } else {
-                remapInternalType("L$target;").drop(1).dropLast(1)
-            }
+        return when {
+            target.startsWith('(') -> return remapMethodDesc(target)
+            target.contains(':') || target.contains('(') -> remapFullyQualifiedMethodOrField(target)
+            target[0] == 'L' -> remapInternalType(target)
+            else -> remapInternalType("L$target;").drop(1).dropLast(1)
         }
     }
 


### PR DESCRIPTION
`NEW` targets in injects can use a bare descriptor for their `target`. This is the default syntax choice for the Minecraft Development IntelliJ plugin.

Example:
```java
at = @At(
    value = "NEW",
    target = "(Lnet/minecraft/world/level/Level;DDDLnet/minecraft/world/item/ItemStack;)Lnet/minecraft/world/entity/item/ItemEntity;"
)
```