### PR TITLE
fix anonymous classes not being resolved

### DIFF
--- a/src/test/kotlin/com/replaymod/gradle/remap/mapper/mixin/TestMixinShadow.kt
+++ b/src/test/kotlin/com/replaymod/gradle/remap/mapper/mixin/TestMixinShadow.kt
@@ -23,4 +23,24 @@ class TestMixinShadow {
             }
         """.trimIndent()
     }
+
+
+    @Test
+    fun `resolve shadow names in anonymous classes`() {
+        TestData.remap("""
+            @org.spongepowered.asm.mixin.Mixin(targets = "a.pkg.A$2")
+            abstract class MixinA {
+                @org.spongepowered.asm.mixin.Shadow
+                protected abstract void aMethodAnon();
+                private void test() { this.aMethodAnon(); }
+            }
+        """.trimIndent()) shouldBe """
+            @org.spongepowered.asm.mixin.Mixin(targets = "b.pkg.B$2")
+            abstract class MixinA {
+                @org.spongepowered.asm.mixin.Shadow
+                protected abstract void bMethodAnon();
+                private void test() { this.bMethodAnon(); }
+            }
+        """.trimIndent()
+    }
 }

--- a/src/test/resources/mappings.srg
+++ b/src/test/resources/mappings.srg
@@ -24,6 +24,8 @@ MD: a/pkg/A/aOverloaded (Z)V b/pkg/B/bOverloaded (Z)V
 MD: a/pkg/A/commonOverloaded (Ljava/lang/Object;)V b/pkg/B/commonOverloaded (Ljava/lang/Object;)V
 MD: a/pkg/A/commonOverloaded (La/pkg/A;)V b/pkg/B/commonOverloaded (La/pkg/B;)V
 CL: a/pkg/A$1 b/pkg/B$1
+CL: a/pkg/A$2 b/pkg/B$2
+MD: a/pkg/A$2/aMethodAnon ()V b/pkg/B$2/bMethodAnon ()V
 CL: a/pkg/A$Inner b/pkg/B$Inner
 FD: a/pkg/A$Inner/aField b/pkg/B$Inner/bField
 CL: a/pkg/A$InnerA b/pkg/B$InnerB

--- a/src/testA/java/a/pkg/A.java
+++ b/src/testA/java/a/pkg/A.java
@@ -101,6 +101,13 @@ public class A extends AParent implements AInterface {
         new A() {};
     }
 
+    public void aAnon() {
+        new A() {
+            public void aMethodAnon() {
+            }
+        };
+    }
+
     public static void supplier(Supplier<String> supplier) {
     }
 

--- a/src/testB/java/b/pkg/B.java
+++ b/src/testB/java/b/pkg/B.java
@@ -98,6 +98,13 @@ public class B extends BParent implements BInterface {
         new B() {};
     }
 
+    public void bAnon() {
+        new B() {
+            public void bMethodAnon() {
+            }
+        };
+    }
+
     public class Inner {
         private int bField;
     }


### PR DESCRIPTION
it seems from my testing that anonymous classes in mixins weren't being resolved.
this seems because they are excluded by the normal resolve functions. so grab the outer, and pull its anonymous class directly (it's also excluded from being resolved as an inner class from that, so `getChildrenByType` is requried)