### PR TITLE
Add support for Kotlin 1.9.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.5.21"
+    kotlin("jvm") version "1.9.23"
     `maven-publish`
 }
 
@@ -22,6 +22,7 @@ val testB by sourceSets.creating
 
 kotlinVersion("1.5.21", isPrimaryVersion = true)
 kotlinVersion("1.6.20")
+kotlinVersion("1.9.0")
 
 dependencies {
     api("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.5.21")
@@ -51,6 +52,13 @@ publishing {
 
 tasks.test {
     useJUnitPlatform()
+}
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions {
+        apiVersion = "1.5"
+        languageVersion = "1.5"
+    }
 }
 
 fun kotlinVersion(version: String, isPrimaryVersion: Boolean = false) {

--- a/src/kotlin1521/kotlin/com/replaymod/gradle/remap/kotlin1521.kt
+++ b/src/kotlin1521/kotlin/com/replaymod/gradle/remap/kotlin1521.kt
@@ -1,6 +1,7 @@
 package com.replaymod.gradle.remap
 
 import org.jetbrains.kotlin.analyzer.AnalysisResult
+import org.jetbrains.kotlin.cli.common.config.KotlinSourceRoot
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.cli.jvm.compiler.NoScopeRecordCliBindingTrace
 import org.jetbrains.kotlin.cli.jvm.compiler.TopDownAnalyzerFacadeForJVM
@@ -16,3 +17,5 @@ fun analyze1521(environment: KotlinCoreEnvironment, ktFiles: List<KtFile>): Anal
         { scope: GlobalSearchScope -> environment.createPackagePartProvider(scope) }
     )
 }
+
+fun kotlinSourceRoot1521(path: String, isCommon: Boolean) = KotlinSourceRoot(path, isCommon)

--- a/src/kotlin190/kotlin/com/replaymod/gradle/remap/kotlin190.kt
+++ b/src/kotlin190/kotlin/com/replaymod/gradle/remap/kotlin190.kt
@@ -1,0 +1,5 @@
+package com.replaymod.gradle.remap
+
+import org.jetbrains.kotlin.cli.common.config.KotlinSourceRoot
+
+fun kotlinSourceRoot190(path: String, isCommon: Boolean) = KotlinSourceRoot(path, isCommon, null)

--- a/src/main/kotlin/com/replaymod/gradle/remap/Transformer.kt
+++ b/src/main/kotlin/com/replaymod/gradle/remap/Transformer.kt
@@ -4,7 +4,6 @@ import com.replaymod.gradle.remap.legacy.LegacyMapping
 import org.cadixdev.lorenz.MappingSet
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.config.ContentRoot
-import org.jetbrains.kotlin.cli.common.config.KotlinSourceRoot
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.cli.common.messages.MessageRenderer
 import org.jetbrains.kotlin.cli.common.messages.PrintingMessageCollector
@@ -73,7 +72,12 @@ class Transformer(private val map: MappingSet) {
             config.put(CommonConfigurationKeys.MODULE_NAME, "main")
             jdkHome?.let {config.setupJdk(it) }
             config.add<ContentRoot>(CLIConfigurationKeys.CONTENT_ROOTS, JavaSourceRoot(tmpDir.toFile(), ""))
-            config.add<ContentRoot>(CLIConfigurationKeys.CONTENT_ROOTS, KotlinSourceRoot(tmpDir.toAbsolutePath().toString(), false))
+            val kotlinSourceRoot = try {
+                kotlinSourceRoot1521(tmpDir.toAbsolutePath().toString(), false)
+            } catch (e: NoSuchMethodError) {
+                kotlinSourceRoot190(tmpDir.toAbsolutePath().toString(), false)
+            }
+            config.add<ContentRoot>(CLIConfigurationKeys.CONTENT_ROOTS, kotlinSourceRoot)
             config.addAll<ContentRoot>(CLIConfigurationKeys.CONTENT_ROOTS, classpath!!.map { JvmClasspathRoot(File(it)) })
             config.put<MessageCollector>(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, PrintingMessageCollector(System.err, MessageRenderer.GRADLE_STYLE, true))
 


### PR DESCRIPTION
Supersedes #17 

The KotlinSourceRoot constructor was updated to include an additional argument related to Kotlin Multiplatform. We always pass null for this argument.

This changes the previous PR in the following ways:
1. Update the kotlin compiler so that we can compile against the kotlin 1.9.0 compiler library. We set and api and language version of 1.5 for backwards compatible.
2. Catch `NoSuchMethodError` instead of `NoSuchMethodException`, since the former is what is actually thrown.

All tests pass using Java 17. They fail locally for me when using Java 8, seemingly because `java.home` points to the JRE subdirectory, so `jdkHome` isn't actually a jdk home. This may be due to how Arch packages Java. https://github.com/ReplayMod/remap/blob/3a12dc22d6ec3924067c7b32582cb6a1ed113344/src/test/kotlin/com/replaymod/gradle/remap/util/TestData.kt#L41

Please bump the version in `preprocessor` once merged.