### PR TITLE
Fix Inner Class Mapping Overrides

### DIFF
--- a/src/main/kotlin/com/replaymod/gradle/remap/legacy/LegacyMappingSetModelFactory.kt
+++ b/src/main/kotlin/com/replaymod/gradle/remap/legacy/LegacyMappingSetModelFactory.kt
@@ -3,7 +3,10 @@ package com.replaymod.gradle.remap.legacy
 import org.cadixdev.bombe.type.signature.MethodSignature
 import org.cadixdev.lorenz.MappingSet
 import org.cadixdev.lorenz.impl.MappingSetModelFactoryImpl
+import org.cadixdev.lorenz.impl.model.InnerClassMappingImpl
 import org.cadixdev.lorenz.impl.model.TopLevelClassMappingImpl
+import org.cadixdev.lorenz.model.ClassMapping
+import org.cadixdev.lorenz.model.InnerClassMapping
 import org.cadixdev.lorenz.model.MethodMapping
 import org.cadixdev.lorenz.model.TopLevelClassMapping
 import java.util.*
@@ -11,6 +14,31 @@ import java.util.*
 class LegacyMappingSetModelFactory : MappingSetModelFactoryImpl() {
     override fun createTopLevelClassMapping(parent: MappingSet, obfuscatedName: String, deobfuscatedName: String): TopLevelClassMapping {
         return object : TopLevelClassMappingImpl(parent, obfuscatedName, deobfuscatedName) {
+            private fun stripDesc(signature: MethodSignature): MethodSignature {
+                // actual descriptor isn't included in legacy format
+                return MethodSignature.of(signature.name, "()V")
+            }
+
+            override fun hasMethodMapping(signature: MethodSignature): Boolean {
+                return super.hasMethodMapping(signature) || super.hasMethodMapping(stripDesc(signature))
+            }
+
+            override fun getMethodMapping(signature: MethodSignature): Optional<MethodMapping> {
+                var maybeMapping = super.getMethodMapping(signature)
+                if (!maybeMapping.isPresent || maybeMapping.get().let { it.signature == it.deobfuscatedSignature }) {
+                    maybeMapping = super.getMethodMapping(stripDesc(signature))
+                }
+                return maybeMapping
+            }
+        }
+    }
+
+    override fun createInnerClassMapping(
+        parent: ClassMapping<out ClassMapping<*, *>, *>?,
+        obfuscatedName: String?,
+        deobfuscatedName: String?
+    ): InnerClassMapping {
+        return object : InnerClassMappingImpl(parent, obfuscatedName, deobfuscatedName) {
             private fun stripDesc(signature: MethodSignature): MethodSignature {
                 // actual descriptor isn't included in legacy format
                 return MethodSignature.of(signature.name, "()V")

--- a/src/test/kotlin/com/replaymod/gradle/remap/mapper/kotlin/TestInnerClass.kt
+++ b/src/test/kotlin/com/replaymod/gradle/remap/mapper/kotlin/TestInnerClass.kt
@@ -1,0 +1,25 @@
+package com.replaymod.gradle.remap.mapper.kotlin
+
+import com.replaymod.gradle.remap.util.TestData
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class TestInnerClass {
+    @Test
+    fun `remaps non inner method`() {
+        TestData.remapKt("""
+            fun apply(x: a.pkg.A) = x.notAInnerMethod()
+        """.trimIndent()) shouldBe """
+            fun apply(x: b.pkg.B) = x.notBInnerMethod()
+        """.trimIndent()
+    }
+
+    @Test
+    fun `remaps method in inner class`() {
+        TestData.remapKt("""
+            fun apply(x: a.pkg.A.InnerA) = x.aMethod()
+        """.trimIndent()) shouldBe """
+            fun apply(x: b.pkg.B.InnerB) = x.bMethod()
+        """.trimIndent()
+    }
+}

--- a/src/test/resources/mappings.srg
+++ b/src/test/resources/mappings.srg
@@ -26,7 +26,9 @@ MD: a/pkg/A/commonOverloaded (La/pkg/A;)V b/pkg/B/commonOverloaded (La/pkg/B;)V
 CL: a/pkg/A$1 b/pkg/B$1
 CL: a/pkg/A$Inner b/pkg/B$Inner
 FD: a/pkg/A$Inner/aField b/pkg/B$Inner/bField
+MD: a/pkg/A/notAInnerMethod ()V b/pkg/A/notBInnerMethod ()V
 CL: a/pkg/A$InnerA b/pkg/B$InnerB
+MD: a/pkg/A$InnerA/aMethod ()V b/pkg/A$InnerB/bMethod ()V
 CL: a/pkg/A$GenericA b/pkg/B$GenericB
 CL: a/pkg/AParent b/pkg/BParent
 MD: a/pkg/AParent/aParentMethod ()V b/pkg/BParent/bParentMethod ()V

--- a/src/testA/java/a/pkg/A.java
+++ b/src/testA/java/a/pkg/A.java
@@ -111,7 +111,14 @@ public class A extends AParent implements AInterface {
         private int aField;
     }
 
+    public int notAInnerMethod() {
+        return 0;
+    }
+
     public class InnerA {
+        public int aMethod() {
+            return 0;
+        }
     }
 
     public class GenericA<T> {}

--- a/src/testB/java/b/pkg/B.java
+++ b/src/testB/java/b/pkg/B.java
@@ -102,7 +102,14 @@ public class B extends BParent implements BInterface {
         private int bField;
     }
 
+    public int notBInnerMethod() {
+        return 0;
+    }
+
     public class InnerB {
+        public int bMethod() {
+            return 0;
+        }
     }
 
     public class GenericB<T> {}


### PR DESCRIPTION
Mapping overrides don't work for methods in inner classes because `LegacyMappingSetModelFactory` doesn't override `createInnerClassMapping`, so the descriptor stripping isn't applied.

Huge thanks to @DJtheRedstoner for helping to debug and solve this.