### PR TITLE
Always try to remap mixins regardless of mappings

### DIFF
--- a/src/main/kotlin/com/replaymod/gradle/remap/PsiMapper.kt
+++ b/src/main/kotlin/com/replaymod/gradle/remap/PsiMapper.kt
@@ -658,12 +658,8 @@ internal class PsiMapper(
 
                 mixinMappings[psiClass.qualifiedName!!] = mapping
 
-                if (!mapping.fieldMappings.isEmpty()) {
-                    remapAccessors(mapping)
-                }
-                if (!mapping.methodMappings.isEmpty()) {
-                    remapMixinInjections(targetClass, mapping)
-                }
+                remapAccessors(mapping)
+                remapMixinInjections(targetClass, mapping)
             }
         })
 


### PR DESCRIPTION
Previously, this incorrectly did not remap any classes that might be sub classes of a super type but do not define any of their own fields or methods.